### PR TITLE
Исправлена ошибка при создании датасета с изображениями (ГАН).

### DIFF
--- a/terra_ai/datasets/arrays_create.py
+++ b/terra_ai/datasets/arrays_create.py
@@ -37,7 +37,7 @@ class CreateArray(object):
         for elem in paths_list:
             try:
                 img = load_img(elem)
-                p_list.append(';'.join([elem, f'{img.height},{img.width}']))
+                p_list.append(';'.join([str(elem), f'{img.height},{img.width}']))
             except (UnidentifiedImageError, IOError):
                 pass
 


### PR DESCRIPTION
';'.join([]) принимал объект pathlib.Path. Перевел его в str